### PR TITLE
Prevent exception if last_run.txt is empty.

### DIFF
--- a/service.py
+++ b/service.py
@@ -313,8 +313,11 @@ class AutoUpdater:
     def readLastRun(self):
         
         try:
+            self.last_run = 0
             f = open(unicode(xbmc.translatePath(self.datadir + "last_run.txt"),'utf-8'),"r")
-            self.last_run = float(f.read())
+            strlastRun = f.read()
+            if len(strlastRun) != 0 :
+                self.last_run = float(strlastRun) 
             f.close()
         except IOError:
             #the file doesn't exist, most likely first time running


### PR DESCRIPTION
```

20:53:49 T:3068128112   ERROR: Traceback (most recent call last):
                                              File "/.xbmc/addons/service.libraryautoupdate/manual.py", line 8, in <module>
                                                autoUpdate = AutoUpdater()
                                              File "//.xbmc/addons/service.libraryautoupdate/service.py", line 50, in __init__
                                                self.readLastRun()
                                              File "//.xbmc/addons/service.libraryautoupdate/service.py", line 317, in readLastRun
                                                self.last_run = float(f.read())
                                            ValueError: could not convert string to float:
```
