### PR TITLE
Catch Cron Errors

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -98,6 +98,10 @@ msgctxt "#30015"
 msgid "Disable manual run prompt"
 msgstr "Disable manual run prompt"
 
+msgctxt "#30016"
+msgid "Cron syntax %s is incorrect, defaulting to 2 hours"
+msgstr "Cron syntax %s is incorrect, defaulting to 2 hours"
+
 msgctxt "#30020"
 msgid "Edit Custom Paths"
 msgstr "Edit Custom Paths"

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -99,6 +99,10 @@ msgctxt "#30015"
 msgid "Disable manual run prompt"
 msgstr "Disable manual run prompt"
 
+msgctxt "#30016"
+msgid "Cron syntax %s is incorrect, defaulting to 2 hours"
+msgstr "Cron syntax %s is incorrect, defaulting to 2 hours"
+
 msgctxt "#30020"
 msgid "Update Specific Path 1"
 msgstr "Update Specific Path 1"

--- a/service.py
+++ b/service.py
@@ -218,11 +218,20 @@ class AutoUpdater:
         return result
     
     def calcNextRun(self,cronExp,startTime):
+        nextRun = -1
         
-        #create croniter for this expression
-        cron = croniter(cronExp,startTime)
-        nextRun = cron.get_next(float)
+        try:        
+            #create croniter for this expression
+            cron = croniter(cronExp,startTime)
+            nextRun = cron.get_next(float)
+        except ValueError:
+            #error in syntax
+            xbmcgui.Dialog().ok(utils.getString(30000),utils.getString(30016) % cronExp)
+            utils.log('Cron syntax error %s' % cronExp,xbmc.LOGDEBUG)
 
+            #rerun with a valid syntax
+            nextRun = self.calcNextRun('0 */2 * * *',startTime)
+            
         return nextRun
 
     def showNotify(self,displayToScreen = True):


### PR DESCRIPTION
This will catch errors in cron syntax as schedules are loaded. The user is informed and the syntax corrected to a default of every 2 hrs. Once fixed by the user it will re-load and run the way they intended. 