### PR TITLE
added urllib2

### DIFF
--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -1,5 +1,6 @@
 # -*- coding: cp1252 -*-
 import time
+import urllib2
 from datetime import datetime
 from kodi_six import xbmc, xbmcgui, xbmcvfs
 from future.moves.urllib.request import urlopen, unquote


### PR DESCRIPTION
I'm running your addon on Coreelec (a standalone OS version of Kodi for ARM boards) and I've been getting the following error recently:
```
ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.NameError'>
                                            Error Contents: global name 'urllib2' is not defined
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/service.libraryautoupdate/default.py", line 6, in <module>
                                                AutoUpdater().runProgram()
                                              File "/storage/.kodi/addons/service.libraryautoupdate/service.py", line 63, in runProgram
                                                self.evalSchedules()
                                              File "/storage/.kodi/addons/service.libraryautoupdate/service.py", line 89, in evalSchedules
                                                if(self._networkUp() and (not utils.getSettingBool('check_sources') or (utils.getSettingBool('check_sources') and self._checkSources(cronJob)))):
                                              File "/storage/.kodi/addons/service.libraryautoupdate/service.py", line 378, in _checkSources
                                                if(not self._sourceExists(source['file'])):
                                              File "/storage/.kodi/addons/service.libraryautoupdate/service.py", line 401, in _sourceExists
                                                if not xbmcvfs.exists(urllib2.unquote(aSource)):
                                            NameError: global name 'urllib2' is not defined
                                            -->End of Python script error report<--
```

Coreelec doesn't allow the installation of anything via a repository such as APT, but adding `urllib2` to the service.py file fixed the issue for me.
Any chance you could add it?