### PR TITLE
use a proper connectivity check instead of google.com

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.libraryautoupdate"
-    name="Library Auto Update" version="1.2.4~beta1" provider-name="robweber">
+    name="Library Auto Update" version="1.2.5" provider-name="robweber">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.dateutil" version="2.7.3" />
@@ -16,8 +16,8 @@
 	<assets>
 		<icon>resources/media/icon.png</icon>
 	</assets>
-	<news>Version 1.2.4
-Updated lang files using Weblate integration</news>
+	<news>Version 1.2.5
+use a connection check URL instead of google.com</news>
     <summary lang="be_BY">Update your Kodi Video and Music Libraries on a timer. Timer runs as an Kodi service so you never miss an update.</summary>
     <summary lang="bg_BG">Обновява библиотеките в Kodi (за видео и музика) чрез брояч. Той се стартира като Kodi услуга, затова никога няма да изпуснете нито едно обновяване.</summary>
     <summary lang="ca_ES">Actualitza les llibreries de vídeo i música de l'Kodi amb un temporitzador. El temporitzador arranca com un servei de l'Kodi, per tant mai es perdrà una actualització.</summary>

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -337,7 +337,7 @@ class AutoUpdater:
 
     def _networkUp(self):
         try:
-            urlopen('http://www.google.com', timeout=1)
+            urlopen('http://connectivitycheck.gstatic.com/generate_204', timeout=1)
             return True
         except Exception:
             pass


### PR DESCRIPTION
libraryautoupdate performs a connectivity check before scanning the library. Previously, this check fetched www.google.com, which is inappropriate for a connection check.

This commit fixes the problem by fetching a static connectivity check page, which returns a 204 status code with an empty response.

Note: I bumped the version to 1.2.5 because after the [merge](https://github.com/xbmc/repo-scripts/pull/2433) this repo contains changes that differ from the upstream Kodi release. Maybe you want to fix this a different way, but it seemed like the most obvious choice would be to bring everything back into sync once you decide to release 1.2.5.